### PR TITLE
Fix README sentence line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Codex Notes 🧠
 
 Proyecto de ejemplo para demostrar cómo GitHub Copilot puede ayudarte a programar.
-
 ## Funciones
 
 - Crear, leer, listar y eliminar notas en un archivo JSON.


### PR DESCRIPTION
## Summary
- update README so GitHub Copilot sentence is on one line

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685e419f05148333a6c678b1c6cdaba6